### PR TITLE
Fix the reuse procedure of garbage lists

### DIFF
--- a/include/memory/epoch_based_gc.hpp
+++ b/include/memory/epoch_based_gc.hpp
@@ -224,6 +224,7 @@ class EpochBasedGC
   GetPageIfPossible()  //
       -> void *
   {
+    static_assert(Target::kReusePages);
     return GetGarbageList<Target>()->GetPageIfPossible();
   }
 
@@ -286,6 +287,7 @@ class EpochBasedGC
   void
   GetPageIfPossible(PMEMoid *out_oid)
   {
+    static_assert(Target::kReusePages);
     GetGarbageList<Target>()->GetPageIfPossible(out_oid);
   }
 #endif


### PR DESCRIPTION
If a thread reused a garbage list previously used by another thread, it would sometimes get nullptr when reusing pages.